### PR TITLE
feat: implement dynamic context window based on token limit

### DIFF
--- a/LLMChat/config/config.json
+++ b/LLMChat/config/config.json
@@ -8,7 +8,8 @@
     "ai": {
       "api_url": "https://api.deepseek.com/chat/completions",
       "token": "sk-xxx",
-      "model": "deepseek-chat"
+      "model": "deepseek-chat",
+      "max_context_tokens": 15000
     }
 }
   

--- a/LLMChat/llm.py
+++ b/LLMChat/llm.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-from utils import get_history_file, load_conversation_history, save_conversation_history
+from utils import get_history_file, load_conversation_history, save_conversation_history, estimate_tokens
 from config import CONFIG
 
 def get_ai_response(conversation):
@@ -55,21 +55,98 @@ def get_ai_response(conversation):
         yield buffer.strip()
 
 
+def build_context_within_limit(full_history):
+    """根据配置的 max_context_tokens 构建不超过限制的上下文"""
+    max_tokens = CONFIG["ai"].get("max_context_tokens", 15000)
+    context = []
+    current_tokens = 0
+
+    # 分离系统提示和对话历史
+    system_prompt = None
+    dialog_history = []
+    if full_history and full_history[0]["role"] == "system":
+        system_prompt = full_history[0]
+        dialog_history = full_history[1:]
+    else:
+        dialog_history = full_history
+
+    # 确保系统提示总是包含在内（如果存在）
+    if system_prompt:
+        system_tokens = estimate_tokens(system_prompt.get("content", ""))
+        if system_tokens <= max_tokens:
+            context.append(system_prompt)
+            current_tokens += system_tokens
+        else:
+            # 如果系统提示本身就超限，那就不包含它了
+            print(f"警告：系统提示过长 ({system_tokens} tokens)，已超过最大限制 {max_tokens} tokens，本次请求将不包含系统提示。")
+            system_prompt = None # 确保下面不会再次添加
+
+    # 从最新的消息开始向前添加，直到达到 Token 上限
+    for message in reversed(dialog_history):
+        message_content = message.get("content", "")
+        message_tokens = estimate_tokens(message_content)
+
+        # 如果加上这条消息会超限，并且上下文已有内容（至少有系统提示或之前的消息），则停止添加
+        if current_tokens + message_tokens > max_tokens and context:
+             # 如果第一条用户消息就超长，则必须包含它（但可能需要截断）
+            break
+
+        # 插入到上下文的开头（因为是从后往前遍历）
+        # 如果 context 为空，说明这是第一条要加入的消息（可能是用户消息或历史消息）
+        if not context and system_prompt:
+             # 如果有系统提示，则插入到系统提示之后
+             context.insert(1, message)
+        else:
+             # 如果没有系统提示，或者已有其他消息，则插入到最前面
+             context.insert(0 if not system_prompt else 1, message)
+
+        current_tokens += message_tokens
+
+        # 加上最新消息后刚好超限
+        if current_tokens > max_tokens and len(context) == (1 if not system_prompt else 2):
+             print(f"警告：最新的消息过长 ({message_tokens} tokens)，可能导致上下文被截断。")
+             pass
+
+    # 如果 context 为空，至少要包含最新的用户消息
+    if not context and dialog_history:
+        last_message = dialog_history[-1]
+        last_content = last_message.get("content", "")
+        last_tokens = estimate_tokens(last_content)
+        if last_tokens <= max_tokens:
+            context.append(last_message)
+            current_tokens += last_tokens
+
+    print(f"构建上下文：包含 {len(context)} 条消息，估算 {current_tokens} tokens (上限 {max_tokens})。原始历史 {len(full_history)} 条。")
+    return context
+
+
 def process_conversation(chat_id, user_input, chat_type="private"):
     """
     chat_id：私聊中为用户QQ，群聊中为群号；
     user_input：用户输入的消息文本（群聊时外部已去除 # 前缀）；
     chat_type: "private" 或 "group"
     """
-    history = load_conversation_history(chat_id, chat_type)
-    history.append({"role": "user", "content": user_input})
+    # 1. 加载完整历史记录
+    full_history = load_conversation_history(chat_id, chat_type)
+
+    # 2. 将当前用户输入添加到完整历史记录中（用于保存）
+    full_history.append({"role": "user", "content": user_input})
+
+    # 3. 基于完整历史记录构建本次请求的上下文（滑动窗口）
+    context_to_send = build_context_within_limit(full_history)
+
     response_segments = []
+    full_response = ""
     try:
-        for segment in get_ai_response(history):
+        # 4. 使用构建好的上下文调用 AI
+        for segment in get_ai_response(context_to_send):
             response_segments.append(segment)
             yield segment
+        full_response = "\n".join(response_segments)
     except Exception as e:
         yield f"AI响应出错: {e}"
-    full_response = "\n".join(response_segments)
-    history.append({"role": "assistant", "content": full_response})
-    save_conversation_history(chat_id, history, chat_type)
+    # 5. 将 AI 的完整回复添加到完整历史记录中
+    full_history.append({"role": "assistant", "content": full_response})
+
+    # 6. 保存完整历史记录到文件
+    save_conversation_history(chat_id, full_history, chat_type)

--- a/LLMChat/utils.py
+++ b/LLMChat/utils.py
@@ -39,3 +39,10 @@ def save_conversation_history(id_str, history, chat_type="private"):
     history_file = get_history_file(id_str, chat_type)
     with open(history_file, "w", encoding="utf-8") as f:
         json.dump(history, f, ensure_ascii=False, indent=2)
+
+def estimate_tokens(text):
+    """基于字符数估算 Token 数，平均 1.5 字符约为 1 Token（虽然tokenizer更准确但是要挂梯子来下文件"""
+    if not isinstance(text, str):
+        return 0
+    estimated_tokens = (len(text) * 2) // 3 + 1
+    return estimated_tokens


### PR DESCRIPTION
This PR implements a dynamic context window mechanism.

**Changes:**

- Added `max_context_tokens` setting (default 15000) to `LLMChat/config/config.json` under the `ai` section.
- Added `estimate_tokens` function in `LLMChat/utils.py` for basic token estimation based on character count.
- Modified `LLMChat/llm.py`:
    - Added `build_context_within_limit` function to construct the message list sent to the LLM.
    - This function ensures the system prompt is included (if it fits) and then adds messages from the end of the history backwards until the estimated token count approaches `max_context_tokens`.
    - `process_conversation` now uses `build_context_within_limit` to create the context for the LLM API call, while still saving the complete conversation history.

**Note:** Token estimation is basic (characters / 1.5). Actual token count may vary.