### PR TITLE
fix(utils): robustly handle DashScope list response in describe_image

### DIFF
--- a/LLMChat/tests/test_image_recognition.py
+++ b/LLMChat/tests/test_image_recognition.py
@@ -7,9 +7,9 @@ from config import CONFIG
 
 # 动态设置 image_ai 配置
 CONFIG["image_ai"] = {
-    "api_url": "",
-    "token": "",
-    "model": "" 
+    "api_url": "https://dashscope.aliyuncs.com/api/v1/services/vision/text-image-generation/generation",
+    "token": "sk-89e09d80ab994548bf28fcedc01cd791",
+    "model": "qwen-vl-plus"
 }
 
 IMAGE_PATH = r"E:\Users\Shuakami\Pictures\b_1a4986c89ad467790613b670c9856082.jpg"

--- a/LLMChat/utils/message_content.py
+++ b/LLMChat/utils/message_content.py
@@ -27,8 +27,20 @@ def describe_image(image_source: str, image_type: str = "url") -> str:
     ]
     try:
         desc = get_ai_response_with_image(conversation, image=image_source, image_type=image_type)
-        print(f"[DEBUG] describe_image: Success, desc='{desc[:100]}...' ")
-        return f"[图片内容描述: {desc.strip()}]"
+        print(f"[DEBUG] describe_image: Success, desc='{str(desc)[:100]}...' ")
+        # 兼容 desc 为 list 或 str
+        desc_text = None
+        if isinstance(desc, list):
+            # 取第一个元素的 text 字段
+            if desc and isinstance(desc[0], dict) and 'text' in desc[0]:
+                desc_text = desc[0]['text']
+            else:
+                desc_text = str(desc)
+        elif isinstance(desc, str):
+            desc_text = desc
+        else:
+            desc_text = str(desc)
+        return f"[图片内容描述: {desc_text.strip()}]"
     except Exception as e:
         print(f"[ERROR] describe_image: Failed, error='{str(e)}'")
         return f"[图片内容描述获取失败: {str(e)}]"


### PR DESCRIPTION
### Problem

When using DashScope as the image description backend, the API may return a list of objects instead of a plain string. The original implementation of `describe_image` directly called `strip()` on the response, which caused a runtime error: `list object has no attribute 'strip'`.

### Solution

- Added type checking in `describe_image` to handle both list and string responses.
- If the response is a list, the function now extracts the `text` field from the first element.
- If the response is a string, it is processed as before.
- This ensures compatibility with DashScope and prevents type errors.

### Impact

- Fixes image description failures when using DashScope.
- Improves robustness and compatibility of the image description logic.

---

Closes: #bug (if any)

---

**Test Plan:**
- Use both DashScope and other compatible APIs to describe images.
- Confirm that no type errors occur and the description is returned as expected.