### PR TITLE
refactor(tests): remove hardcoded API token from image recognition test

### DIFF
--- a/LLMChat/tests/test_image_recognition.py
+++ b/LLMChat/tests/test_image_recognition.py
@@ -8,7 +8,7 @@ from config import CONFIG
 # 动态设置 image_ai 配置
 CONFIG["image_ai"] = {
     "api_url": "https://dashscope.aliyuncs.com/api/v1/services/vision/text-image-generation/generation",
-    "token": "sk-89e09d80ab994548bf28fcedc01cd791",
+    "token": "",
     "model": "qwen-vl-plus"
 }
 


### PR DESCRIPTION
This PR removes the hardcoded API token from the image recognition test file (`LLMChat/tests/test_image_recognition.py`).

**Reason:**

Storing sensitive credentials like API tokens directly in the codebase is a security risk. This change removes the token to improve security.

**Impact:**

- The test file no longer contains a hardcoded token.
- Tests relying on this configuration might need adjustments to fetch the token from a secure source (e.g., environment variables, configuration files outside version control) during runtime.

---

Addresses security best practices.