### PR TITLE
fix: ensure async group message handler is properly awaited

### DIFF
--- a/LLMChat/napcat/get.py
+++ b/LLMChat/napcat/get.py
@@ -3,6 +3,7 @@ from config import CONFIG
 from napcat.chat_logic import handle_group_message, handle_private_message
 from napcat.command_handler import process_command
 from napcat.message_sender import WebSocketSender
+import asyncio
 
 def handle_incoming_message(message):
     try:
@@ -23,6 +24,10 @@ def handle_incoming_message(message):
             handle_private_message(msg, sender)
         elif msg.get("message_type") == "group":
             if CONFIG["debug"]: print("处理群聊消息")
-            handle_group_message(msg, sender)
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(handle_group_message(msg, sender))
+            except RuntimeError:
+                asyncio.run(handle_group_message(msg, sender))
     except Exception as e:
         print("处理ws消息异常:", e)


### PR DESCRIPTION
### Summary

This PR fixes an issue where the async group message handler (`handle_group_message`) was called without being properly awaited, which caused a `RuntimeWarning: coroutine 'handle_group_message' was never awaited` at runtime.

### Details
- The call to `handle_group_message` in `napcat/get.py` is now wrapped to ensure it is always awaited, using `asyncio.create_task` if an event loop is running, or `asyncio.run` otherwise.
- This guarantees that the async handler is executed correctly in both sync and async contexts, and eliminates the warning.
- No business logic is changed; only the invocation method is updated for correctness and stability.

### Impact
- No breaking changes.
- No API changes.
- Only internal message dispatch logic is affected.

---
fixes #异步调用警告