### PR TITLE
feat: Add role system with approval, dragon handler & fixes

### DIFF
--- a/LLMChat/napcat/command_handler.py
+++ b/LLMChat/napcat/command_handler.py
@@ -25,6 +25,9 @@ def send_reply(msg_dict, reply, sender: IMessageSender):
 
 def process_command(msg_dict, sender: IMessageSender):
     text = extract_text_from_message(msg_dict)
+    sender_qq = str(msg_dict["sender"]["user_id"])
+    admin_qq_list = CONFIG["qqbot"].get("admin_qq", [])
+
     if text.startswith("/arcreset"):
         return process_reset_command(msg_dict, sender)
     elif text.startswith("/archelp"):
@@ -36,7 +39,14 @@ def process_command(msg_dict, sender: IMessageSender):
     elif text.startswith("/arcgrouplist"):
         return process_group_list_command(msg_dict, sender)
     elif text.startswith("/role"):
-        return process_role_command(msg_dict, sender)
+        tokens = text.split()
+        sub_command = tokens[1].lower() if len(tokens) > 1 else "list"
+        # 检查是否是管理员命令
+        if sub_command in ["pending", "approve", "reject"]:
+            return process_role_admin_command(msg_dict, sender)
+        else:
+            # 普通用户的 /role 命令
+            return process_role_command(msg_dict, sender)
     return False
 
 
@@ -313,7 +323,7 @@ def process_role_command(msg_dict, sender: IMessageSender):
         else:
             role_name_to_delete = " ".join(tokens[2:]).strip()
             if role_manager.delete_role(role_name_to_delete):
-                reply = f"角色模板 '{role_name_to_delete}' 已删除。"
+                reply = f"角色模板 '{role_name_to_delete}' 已删除喵...（请注意，删除后无法恢复喵）"
             else:
                 reply = f"删除角色模板 '{role_name_to_delete}' 失败（可能是名称不存在喵？）。"
 
@@ -324,8 +334,106 @@ def process_role_command(msg_dict, sender: IMessageSender):
             reply = "当前还没有任何角色模板喵。使用 /role add 开始添加吧~"
         else:
             reply = "当前可用角色模板：\n - " + "\n - ".join(role_names)
+            reply += "\n\n使用 /role add|edit|delete <名称> 进行管理。"
     else:
-        reply = "无效的 /role 子命令喵。可用：add, edit, delete, list (默认)"
+        reply = "无效的 /role 子命令喵。\n"
+        reply += "用法: \n"
+        reply += "  /role list (或 /role) - 查看可用角色\n"
+        reply += "---- 管理员命令 ----\n"
+        reply += "  /role pending        - 查看待审核角色\n"
+        reply += "  /role approve <审核ID> - 批准角色\n"
+        reply += "  /role reject <审核ID>  - 拒绝角色\n"
+        reply += "--------------------\n"
+        reply += "  /role add          - 添加新角色 (提交审核)\n"
+        reply += "  /role edit <名称> - 编辑现有角色 (按提示操作)\n"
+        reply += "  /role delete <名称> - 删除指定角色"
+
+    if reply:
+        send_reply(msg_dict, reply, sender)
+
+    return True # 表示命令已被处理
+
+# +++ 新增管理员审核处理函数 +++
+def process_role_admin_command(msg_dict, sender: IMessageSender):
+    """处理 /role pending, approve, reject 命令"""
+    text = extract_text_from_message(msg_dict).strip()
+    sender_info = msg_dict["sender"]
+    user_id = str(sender_info["user_id"])
+    message_type = msg_dict.get("message_type")
+    chat_id = str(msg_dict.get("group_id") if message_type == "group" else user_id)
+
+    # 检查管理员权限
+    admin_qq_list = CONFIG["qqbot"].get("admin_qq", [])
+    if user_id not in admin_qq_list:
+        send_reply(msg_dict, "抱歉，只有管理员才能执行此操作喵。", sender)
+        return True # 明确拒绝
+
+    tokens = text.split()
+    if len(tokens) < 2:
+        send_reply(msg_dict, "无效的管理命令。请使用 /role pending, /role approve <ID>, 或 /role reject <ID>", sender)
+        return True
+
+    admin_sub_command = tokens[1].lower()
+    reply = ""
+
+    if admin_sub_command == "pending":
+        pending_roles = role_manager.list_pending_roles()
+        if not pending_roles:
+            reply = "当前没有待审核的角色模板。"
+        else:
+            reply = "待审核的角色列表：\n"
+            for pid, info in pending_roles.items():
+                reply += f"- ID: {pid}\n  名称: {info.get('name', '?')}\n  申请人: {info.get('requester_user_id', '?')}\n  来源: {info.get('requester_chat_type', '?')} {info.get('requester_chat_id', '?')}\n  (Prompt 预览: {info.get('prompt', '')[:30]}...)\n"
+            reply += "\n使用 /role approve <ID> 或 /role reject <ID> 处理。"
+
+    elif admin_sub_command == "approve":
+        if len(tokens) < 3:
+            reply = "请提供要批准的审核 ID: /role approve <审核ID>"
+        else:
+            pending_id_to_approve = tokens[2].strip()
+            success, approved_info = role_manager.approve_pending_role(pending_id_to_approve)
+            if success and approved_info:
+                reply = f"角色 '{approved_info['name']}' (ID: {pending_id_to_approve}) 已批准并添加。"
+                # 通知原申请人
+                try:
+                    notify_msg = f"好耶！你提交的角色模板 '{approved_info['name']}' 已通过审核喵。"
+                    requester_chat_type = approved_info.get("requester_chat_type")
+                    requester_chat_id = approved_info.get("requester_chat_id")
+                    if requester_chat_type == "private":
+                        sender.send_private_msg(int(requester_chat_id), notify_msg)
+                    elif requester_chat_type == "group":
+                        sender.send_group_msg(int(requester_chat_id), notify_msg)
+                except Exception as notify_err:
+                    print(f"[WARN] 批准角色后通知申请人失败: {notify_err}")
+            elif approved_info:
+                reply = f"批准角色 '{approved_info['name']}' (ID: {pending_id_to_approve}) 失败，角色未能添加到主列表（可能重名？）。请检查日志。"
+            else:
+                reply = f"批准失败：找不到审核 ID '{pending_id_to_approve}' 或处理出错。"
+
+    elif admin_sub_command == "reject":
+        if len(tokens) < 3:
+            reply = "请提供要拒绝的审核 ID: /role reject <审核ID>"
+        else:
+            pending_id_to_reject = tokens[2].strip()
+            success, rejected_info = role_manager.reject_pending_role(pending_id_to_reject)
+            if success and rejected_info:
+                reply = f"角色 '{rejected_info['name']}' (ID: {pending_id_to_reject}) 的审核请求已拒绝。"
+                # 通知原申请人
+                try:
+                    notify_msg = f"抱歉，你提交的角色模板 '{rejected_info['name']}' 未通过审核。"
+                    requester_chat_type = rejected_info.get("requester_chat_type")
+                    requester_chat_id = rejected_info.get("requester_chat_id")
+                    if requester_chat_type == "private":
+                        sender.send_private_msg(int(requester_chat_id), notify_msg)
+                    elif requester_chat_type == "group":
+                         # 在群里通知有点奇怪，可以选择私聊通知申请人
+                         sender.send_private_msg(int(rejected_info.get("requester_user_id")), notify_msg)
+                except Exception as notify_err:
+                    print(f"[WARN] 拒绝角色后通知申请人失败: {notify_err}")
+            else:
+                reply = f"拒绝失败：找不到审核 ID '{pending_id_to_reject}' 或处理出错。"
+    else:
+        reply = "无效的管理命令。请使用 /role pending, /role approve <ID>, 或 /role reject <ID>"
 
     if reply:
         send_reply(msg_dict, reply, sender)

--- a/LLMChat/utils/role_manager.py
+++ b/LLMChat/utils/role_manager.py
@@ -1,40 +1,55 @@
 import json
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple, Any
+import time
+import random
+import string
 
 # 激活角色状态存储
 # key: (chat_id: str, chat_type: str), value: role_name: str (None for default)
 active_roles: Dict[tuple[str, str], Optional[str]] = {}
 
+# 文件路径
 ROLES_FILE = os.path.join("data", "roles.json")
+PENDING_ROLES_FILE = os.path.join("data", "pending_roles.json")
 
-def _ensure_roles_file():
-    """确保角色文件和目录存在"""
-    os.makedirs(os.path.dirname(ROLES_FILE), exist_ok=True)
-    if not os.path.exists(ROLES_FILE):
-        with open(ROLES_FILE, "w", encoding="utf-8") as f:
-            json.dump({}, f, ensure_ascii=False, indent=2)
+def _ensure_file(file_path: str, default_content: Any = {}):
+    """确保 JSON 文件和目录存在"""
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    if not os.path.exists(file_path):
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(default_content, f, ensure_ascii=False, indent=2)
+        except IOError as e:
+            print(f"[ERROR] 创建文件失败: {file_path}, Error: {e}")
+
+def _load_json(file_path: str, default_return: Any = {}) -> Any:
+    """加载 JSON 文件，处理异常"""
+    _ensure_file(file_path, default_return)
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, type(default_return)) else default_return
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"[ERROR] 加载 JSON 文件失败: {file_path}, Error: {e}")
+        return default_return
+
+def _save_json(file_path: str, data: Any):
+    """保存数据到 JSON 文件，处理异常"""
+    _ensure_file(file_path, type(data)()) # 确保文件存在，并传入默认类型
+    try:
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except IOError as e:
+        print(f"[ERROR] 保存 JSON 文件失败: {file_path}, Error: {e}")
 
 def load_roles() -> Dict[str, str]:
     """加载所有角色，返回一个 名字->Prompt 的字典"""
-    _ensure_roles_file()
-    try:
-        with open(ROLES_FILE, "r", encoding="utf-8") as f:
-            roles = json.load(f)
-            # 确保返回的是字典
-            return roles if isinstance(roles, dict) else {}
-    except (json.JSONDecodeError, IOError) as e:
-        print(f"[ERROR] 加载角色文件失败: {e}")
-        return {}
+    return _load_json(ROLES_FILE, default_return={})
 
 def save_roles(roles: Dict[str, str]):
     """保存角色字典到文件"""
-    _ensure_roles_file()
-    try:
-        with open(ROLES_FILE, "w", encoding="utf-8") as f:
-            json.dump(roles, f, ensure_ascii=False, indent=2)
-    except IOError as e:
-        print(f"[ERROR] 保存角色文件失败: {e}")
+    _save_json(ROLES_FILE, roles)
 
 def add_role(name: str, prompt: str) -> bool:
     """添加一个新角色。如果名字已存在则失败。"""
@@ -125,7 +140,7 @@ def get_role_selection_prompt() -> str:
         return "" # 没有自定义角色时，不添加任何提示
     
     prompt = "\n\n角色切换指令\n"
-    prompt += "你可以根据对话内容、氛围或自己的状态，在合适的时机切换到不同的角色来回应。"
+    prompt += "你可以根据对话内容、氛围或自己的状态（比如快睡觉了、受到攻击、不开心或者...），在合适的时机切换到不同的角色来回应。"
     prompt += "可用角色列表：\n"
     prompt += " - 默认(Saki&Nya)\n"
     prompt += "\n".join(f" - {name}" for name in role_names)
@@ -137,5 +152,88 @@ def get_role_selection_prompt() -> str:
     prompt += "\n"
     return prompt
 
+# 待审核角色管理
+def _load_pending_roles() -> Dict[str, Dict]:
+    """加载待审核角色，返回一个 pending_id -> info 的字典"""
+    return _load_json(PENDING_ROLES_FILE, default_return={})
+
+def _save_pending_roles(pending_roles: Dict[str, Dict]):
+    """保存待审核角色字典"""
+    _save_json(PENDING_ROLES_FILE, pending_roles)
+
+def _generate_pending_id() -> str:
+    """生成一个唯一的待审核 ID"""
+    timestamp = int(time.time())
+    random_suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
+    return f"pending_{timestamp}_{random_suffix}"
+
+def stage_role_for_approval(name: str, prompt: str, requester_user_id: str, requester_chat_id: str, requester_chat_type: str) -> Optional[str]:
+    """暂存角色以待审核，返回 pending_id"""
+    pending_roles = _load_pending_roles()
+    pending_id = _generate_pending_id()
+    while pending_id in pending_roles: # 确保 ID 唯一性
+        pending_id = _generate_pending_id()
+        
+    normalized_name = name.strip()
+    if not normalized_name:
+        print("[ERROR] 尝试暂存的角色名称为空")
+        return None
+        
+    pending_roles[pending_id] = {
+        "name": normalized_name,
+        "prompt": prompt.strip(),
+        "requester_user_id": requester_user_id,
+        "requester_chat_id": requester_chat_id,
+        "requester_chat_type": requester_chat_type,
+        "staged_at": int(time.time())
+    }
+    _save_pending_roles(pending_roles)
+    print(f"[INFO] 角色 '{normalized_name}' 已暂存待审核，ID: {pending_id}")
+    return pending_id
+
+def get_pending_role(pending_id: str) -> Optional[Dict]:
+    """获取待审核角色信息"""
+    pending_roles = _load_pending_roles()
+    return pending_roles.get(pending_id)
+
+def approve_pending_role(pending_id: str) -> Tuple[bool, Optional[Dict]]:
+    """批准待审核角色，返回 (是否成功, 批准的角色信息)"""
+    pending_roles = _load_pending_roles()
+    role_info = pending_roles.get(pending_id)
+    
+    if not role_info:
+        print(f"[ERROR] 批准失败：找不到待审核 ID {pending_id}")
+        return False, None
+        
+    # 尝试添加到主列表
+    if add_role(role_info["name"], role_info["prompt"]):
+        # 添加成功，从未决列表中移除
+        del pending_roles[pending_id]
+        _save_pending_roles(pending_roles)
+        print(f"[INFO] 待审核角色 {pending_id} ('{role_info['name']}') 已批准并添加。")
+        return True, role_info
+    else:
+        # 添加失败（可能名称已存在或写入错误），保留在未决列表供检查
+        print(f"[ERROR] 批准角色 {pending_id} ('{role_info['name']}') 后添加到主列表失败。")
+        return False, role_info
+
+def reject_pending_role(pending_id: str) -> Tuple[bool, Optional[Dict]]:
+    """拒绝待审核角色，返回 (是否成功, 被拒绝的角色信息)"""
+    pending_roles = _load_pending_roles()
+    role_info = pending_roles.pop(pending_id, None) # 直接尝试移除
+    
+    if role_info:
+        _save_pending_roles(pending_roles)
+        print(f"[INFO] 待审核角色 {pending_id} ('{role_info['name']}') 已拒绝。")
+        return True, role_info
+    else:
+        print(f"[ERROR] 拒绝失败：找不到待审核 ID {pending_id}")
+        return False, None
+
+def list_pending_roles() -> Dict[str, Dict]:
+    """列出所有待审核的角色"""
+    return _load_pending_roles()
+
 # 初始化时确保文件存在
-_ensure_roles_file() 
+_ensure_file(ROLES_FILE)
+_ensure_file(PENDING_ROLES_FILE) 


### PR DESCRIPTION
This PR introduces several major features and bug fixes:

**Features:**
- **Role Management System:**
    - Commands: `/role list`, `/role add`, `/role edit <name>`, `/role delete <name>` for managing character roles.
    - **Approval Workflow:** `/role add` submissions are now sent to admins for approval via `/role approve <ID>` or `/role reject <ID>`. Applicants are notified of the outcome. Pending roles can be listed with `/role pending`.
    - Roles are stored in `data/roles.json`, pending roles in `data/pending_roles.json`.
- **Role Switching:**
    - Users can switch roles using `/setrole <name>` or `/setrole default`.
    - AI can autonomously switch roles using the internal `[setrole:...]` tag (invisible to users). Instructions added to system prompt.
- **Context Isolation:** Conversation history files are now separated based on the active role (`data/conversation/.../[id]/[role_name_or_default].json`).
- **Dragon Handler:**
    - Detects 3 consecutive identical messages from different users (non-bot).
    - 50% chance to repeat the message (+1), 50% chance to use AI to disrupt the chain.
    - Logic decoupled into `utils/dragon_handler.py`.

**Fixes:**
- Resolved `ImportError: attempted relative import beyond top-level package` in `utils/dragon_handler.py` by using absolute imports.
- Resolved `SyntaxError: f-string: unmatched '['` in `napcat/command_handler.py` by correcting quote usage inside f-strings.
- Fixed `IndentationError` in `utils/ai_message_parser.py`.
- Improved help messages for `/role` command.

**Code Structure:**
- Role logic in `utils/role_manager.py`.
- Dragon logic in `utils/dragon_handler.py`.
- Command logic in `napcat/command_handler.py`.
- State handling and AI tag parsing in `napcat/get.py` and `utils/ai_message_parser.py`.
- History/Prompt loading in `llm.py` and `utils/files.py`.